### PR TITLE
fix: update import path for useRuntimeConfig in setupI18nFromRuntimeC…

### DIFF
--- a/src/runtime/server/utils/render.ts
+++ b/src/runtime/server/utils/render.ts
@@ -74,7 +74,7 @@ async function setupI18nFromRuntimeConfig(
   locale?: string,
 ): Promise<boolean> {
   try {
-    const { useRuntimeConfig } = await import('#imports')
+    const { useRuntimeConfig } = await import('nitropack/runtime')
     const config = useRuntimeConfig()
 
     if (!config.public?.i18n) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The bug was introduced in `v2.1.0` when i18n support was added. 
In the file `render.ts`, the `setupI18nFromRuntimeConfig` function was importing `useRuntimeConfig` from `#imports`.

The `#imports` virtual module includes all auto-imports, including `hubHooks` from `@nuxthub/core`. When Nitro bundled the server code, this caused a Temporal Dead Zone (TDZ) error where `hubHooks` was referenced in the module exports before it was initialized.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
