### PR TITLE
fix: update path handling in nitroInlineAssetPlugin for OS consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,11 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
 
     permissions:
       pull-requests: write

--- a/src/inline-asset-plugin.ts
+++ b/src/inline-asset-plugin.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { dirname, extname, isAbsolute, resolve } from 'node:path'
+import { posix, extname, isAbsolute } from 'node:path'
 
 const INLINE_IMAGE_MIME_TYPES: Record<string, string> = {
   '.gif': 'image/gif',
@@ -8,6 +8,11 @@ const INLINE_IMAGE_MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
   '.webp': 'image/webp',
+}
+
+/** Normalize a path to forward slashes (no-op on POSIX, converts backslashes on Windows). */
+function toForwardSlashes(p: string): string {
+  return p.replace(/\\/g, '/')
 }
 
 /**
@@ -26,10 +31,11 @@ export function nitroInlineAssetPlugin() {
       const cleanSource = source.slice(0, -'?inline'.length)
 
       if (source.startsWith('.') && importer) {
-        return `${resolve(dirname(importer), cleanSource)}?inline`
+        const dir = posix.dirname(toForwardSlashes(importer))
+        return `${posix.join(dir, cleanSource)}?inline`
       }
 
-      if (isAbsolute(cleanSource)) {
+      if (isAbsolute(cleanSource) || posix.isAbsolute(cleanSource)) {
         return source
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The tests now pass on Windows.
CI should validate they still pass on "ubuntu-latest"

See #55 



CI could be changed to run in matrix of "ubuntu-latest" and "windows-latest"

https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/run-job-variations

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
